### PR TITLE
Fix fndre function

### DIFF
--- a/bashark.sh
+++ b/bashark.sh
@@ -713,9 +713,8 @@ fndre(){
             regexes[JCB_regex]="35\d{14}|2131\d{11}|1800\d{11})"  
 
             for key in ${!regexes[@]}; do
-                echo $regexes[$key]
                 print_good "$key search results:"
-                re = $regexes[$key]
+                re=${regexes[$key]}
                 grep -oE "$re" $filename
             done
         fi


### PR DESCRIPTION
**Issue** (see second half of #3 for details)
`fndre` was failing, complaining that `re` is not a known command.

**Resolution**
1. This was due to spaces around the equal sign (=) when declaring the
`re` variable. I removed these spaces to correctly declare the variable.

2. Once this was resolved, the regex matching wouldn't work because 
of a syntax issue to grab elements of the regex array. Braces are 
required to select an value from a keyed array.

**Testing**
I manually tested the updated `fndre` command on a Kali Linux VM, supplying a simple hand-written text file. The input file contains gibberish along with things the regular expressions should find, like `@gmail.com` addresses, IP addresses, and fake credit card numbers.

*Note*  
I removed the `echo` statement on line 716 because it appeared
to be a debug echo, since the subsequent `print_good` call also prints
the key.

Related to #3